### PR TITLE
Solve lag issue in rendering

### DIFF
--- a/gface_streaming.py
+++ b/gface_streaming.py
@@ -165,7 +165,7 @@ class Mediapipe_FaceModule():
         # flip so directions are more intuitive in the shown video. Only do this when using the table, not laptop camera.    
         #frame = cv2.flip(frame,-1)    
 
-        self.timestamp += 1
+        self.timestamp = int(time.time() * 1000)
         mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=frame)
         self.detector.detect_async(mp_image, self.timestamp)
 
@@ -208,7 +208,7 @@ class Mediapipe_FaceModule():
             
 if __name__ == "__main__":
     start_time = time.time()
-    with Mediapipe_FaceModule("Camera_1") as face_module:
+    with Mediapipe_FaceModule("Camera_0") as face_module:
         face_module.time_of_last_callback = start_time
         while face_module.is_open():
             face_module.do_loop(True, time.time())

--- a/ghands_streaming.py
+++ b/ghands_streaming.py
@@ -171,7 +171,7 @@ class Mediapipe_HandsModule():
         # flip so directions are more intuitive in the shown video. Only do this when using the table, not laptop camera.    
         #frame = cv2.flip(frame,-1)    
 
-        self.timestamp += 1
+        self.timestamp = int(time.time() * 1000)
         mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=frame)
         self.landmarker.detect_async(mp_image, self.timestamp)
         self.recognizer.recognize_async(mp_image, self.timestamp)


### PR DESCRIPTION
Use actual timestamps instead of incrementing an integer (as in the example code...). This seems to cause the MediaPipe async prediction model to "skip" frames, thereby resulting in a smoother and more real-time rendering.